### PR TITLE
Fix TypeScript build errors for card upgrades

### DIFF
--- a/cardRendering.ts
+++ b/cardRendering.ts
@@ -2,7 +2,7 @@
 // Shared between gameUI and metaUI for consistent card display.
 
 import { CardSpec, Cost, VariableCost, Trigger, Replacer, Rule } from './gameLogic.js'
-import { renderCost } from './gameLogic.js'
+import { cardSpecCost, cardSpecEffects, cardSpecName, cardSpecReplacers, cardSpecStaticReplacers, cardSpecStaticTriggers, cardSpecTriggers, renderCost } from './gameLogic.js'
 
 // ----------------------------- Helper Functions
 
@@ -14,7 +14,7 @@ function isZero(c: Cost | undefined): boolean {
 
 function renderEffects(spec: CardSpec): string {
     const parts: string[] = []
-    for (const effect of spec.effects || []) {
+    for (const effect of cardSpecEffects(spec)) {
         parts.push(...effect.text)
     }
     return parts.map(x => `<div>${x}</div>`).join('')
@@ -61,10 +61,10 @@ export function cardText(spec: CardSpec): string {
     const buyableHtml = spec.restrictions ? renderBuyable(spec.restrictions) : ''
     const costHtml = spec.variableCosts ? renderVariableCosts(spec.variableCosts) : ''
     const abilitiesHtml = renderAbility(spec)
-    const triggerHtml = (spec.triggers || []).map(x => renderTrigger(x, false)).join('')
-    const replacerHtml = (spec.replacers || []).map(x => renderTrigger(x, false)).join('')
-    const staticTriggerHtml = (spec.staticTriggers || []).map(x => renderTrigger(x, true)).join('')
-    const staticReplacerHtml = (spec.staticReplacers || []).map(x => renderTrigger(x, true)).join('')
+    const triggerHtml = cardSpecTriggers(spec).map(x => renderTrigger(x, false)).join('')
+    const replacerHtml = cardSpecReplacers(spec).map(x => renderTrigger(x, false)).join('')
+    const staticTriggerHtml = cardSpecStaticTriggers(spec).map(x => renderTrigger(x, true)).join('')
+    const staticReplacerHtml = cardSpecStaticReplacers(spec).map(x => renderTrigger(x, true)).join('')
     const rulesHtml = (spec.rules || []).map(renderRuleText).join('')
 
     return [
@@ -77,9 +77,11 @@ export function cardText(spec: CardSpec): string {
 
 // Build full HTML tooltip for a card spec (matching in-game tooltip style)
 export function buildSpecTooltip(spec: CardSpec): string {
-    const buyStr = !isZero(spec.buyCost) ? `(${renderCost(spec.buyCost as Cost)})` : '---'
-    const costStr = !isZero(spec.fixedCost) ? `(${renderCost(spec.fixedCost as Cost)})` : '---'
-    const header = `<div>---${buyStr} ${spec.name} ${costStr}---</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyStr = !isZero(buyCost) ? `(${renderCost(buyCost as Cost)})` : '---'
+    const costStr = !isZero(playCost) ? `(${renderCost(playCost as Cost)})` : '---'
+    const header = `<div>---${buyStr} ${cardSpecName(spec)} ${costStr}---</div>`
     const baseFilling = header + cardText(spec)
 
     // Related cards
@@ -91,9 +93,11 @@ export function buildSpecTooltip(spec: CardSpec): string {
 
 // Render a CardSpec with full details including related cards
 export function renderSpec(spec: CardSpec): string {
-    const buyText = isZero(spec.buyCost) ? '' : `(${renderCost(spec.buyCost as Cost)})&nbsp;`
-    const costText = isZero(spec.fixedCost) ? '' : `&nbsp;(${renderCost(spec.fixedCost as Cost)})`
-    const header = `<div>${buyText}<strong>${spec.name}</strong>${costText}</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyText = isZero(buyCost) ? '' : `(${renderCost(buyCost as Cost)})&nbsp;`
+    const costText = isZero(playCost) ? '' : `&nbsp;(${renderCost(playCost as Cost)})`
+    const header = `<div>${buyText}<strong>${cardSpecName(spec)}</strong>${costText}</div>`
     const me = `<div class='spec'>${header}${cardText(spec)}</div>`
     const related = (spec.relatedCards || []).map(renderSpec)
     return [me, ...related].join('')
@@ -102,9 +106,11 @@ export function renderSpec(spec: CardSpec): string {
 // Render a CardSpec without related cards inline, but with tooltip
 // Uses simpleText if available for compact display
 export function renderSpecNoRelated(spec: CardSpec): string {
-    const buyText = isZero(spec.buyCost) ? '' : `(${renderCost(spec.buyCost as Cost)})&nbsp;`
-    const costText = isZero(spec.fixedCost) ? '' : `&nbsp;(${renderCost(spec.fixedCost as Cost)})`
-    const header = `<div>${buyText}<strong>${spec.name}</strong>${costText}</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyText = isZero(buyCost) ? '' : `(${renderCost(buyCost as Cost)})&nbsp;`
+    const costText = isZero(playCost) ? '' : `&nbsp;(${renderCost(playCost as Cost)})`
+    const header = `<div>${buyText}<strong>${cardSpecName(spec)}</strong>${costText}</div>`
 
     // Use simpleText if available, otherwise full card text
     const displayText = spec.simpleText
@@ -119,9 +125,11 @@ export function renderSpecNoRelated(spec: CardSpec): string {
 
 // Render a simple card header (name + cost) without text
 export function renderSpecHeader(spec: CardSpec): string {
-    const buyText = isZero(spec.buyCost) ? '' : `(${renderCost(spec.buyCost as Cost)})&nbsp;`
-    const costText = isZero(spec.fixedCost) ? '' : `&nbsp;(${renderCost(spec.fixedCost as Cost)})`
-    return `${buyText}<strong>${spec.name}</strong>${costText}`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyText = isZero(buyCost) ? '' : `(${renderCost(buyCost as Cost)})&nbsp;`
+    const costText = isZero(playCost) ? '' : `&nbsp;(${renderCost(playCost as Cost)})`
+    return `${buyText}<strong>${cardSpecName(spec)}</strong>${costText}`
 }
 
 // Render just the simple description (for tooltips in other contexts)
@@ -129,5 +137,5 @@ export function renderSpecSimple(spec: CardSpec): string {
     if (spec.simpleText) {
         return spec.simpleText.join(' ')
     }
-    return spec.name
+    return cardSpecName(spec)
 }

--- a/data/encounters.ts
+++ b/data/encounters.ts
@@ -10,10 +10,14 @@ import { Encounter, registerEncounter, RewardOption,
     compose,
 } from '../metaLogic.js'
 import { emptyBottle, inkwell } from './relics.js'
-import { create, State, CardSpec,
+import { create, State, CardSpec, CardUpgrade,
     cardRewards, eventRewards, relicRewards, potionRewards,
     leq,
     coin,
+    cardSpecCost,
+    cardSpecName,
+    actionsEffect,
+    coinsEffect,
     free
 } from '../gameLogic.js'
 
@@ -23,11 +27,12 @@ import { mirrorBrew } from './potions.js'
 // ----------------------------- Helper Functions
 
 function bottledCard(spec: CardSpec): RelicSpec {
+    const displayName = cardSpecName(spec)
     return {
-        name: `Bottled ${spec.name}`,
+        name: `Bottled ${displayName}`,
         triggers: [{
             kind: 'gameStart',
-            text: `Start each course with a copy of ${spec.name} in hand.`,
+            text: `Start each course with a copy of ${displayName} in hand.`,
             handles: () => true,
             transform: () => async function (state: State) {
                 state = await create(spec, 'hand')(state)
@@ -35,6 +40,13 @@ function bottledCard(spec: CardSpec): RelicSpec {
             }
         }],
         relatedCards: [spec]
+    }
+}
+
+function upgradeCardSpec(spec: CardSpec, upgrade: CardUpgrade): CardSpec {
+    return {
+        ...spec,
+        upgrades: [...(spec.upgrades || []), upgrade],
     }
 }
 
@@ -78,7 +90,9 @@ const findABottle: Encounter = {
     createInitialData: () => ({ selectedIndex: null as number | null }),
     getOptions(data: unknown, metaState: MetaState): RewardOption[] {
         const { selectedIndex } = data as { selectedIndex: number | null }
-        const hasCards = metaState.data.collectedCards.filter(x => leq(x.buyCost || free, coin(5))).length > 0
+        const hasCards = metaState.data.collectedCards.filter(
+            x => leq(cardSpecCost(x, 'buy') || free, coin(5))
+        ).length > 0
 
         return [
             {
@@ -91,7 +105,7 @@ const findABottle: Encounter = {
                     const card = await metaState.ui.chooseCard(
                         metaState,
                         'Choose a card to bottle:',
-                        [...metaState.data.collectedCards.filter(x => leq(x.buyCost || free, coin(5)))],
+                        [...metaState.data.collectedCards.filter(x => leq(cardSpecCost(x, 'buy') || free, coin(5)))],
                         true
                     )
                     if (!card) {
@@ -194,6 +208,81 @@ const mirrorMaker: Encounter = {
     }
 }
 registerEncounter(mirrorMaker)
+
+const polishUpgrade: CardUpgrade = {
+    name: name => `${name}+`,
+    effects: [coinsEffect(1)],
+}
+
+const sharpenUpgrade: CardUpgrade = {
+    name: name => `${name}+`,
+    effects: [actionsEffect(1)],
+}
+
+const redesignUpgrade: CardUpgrade = {
+    name: name => `${name}+`,
+    cost: (cost, kind) => kind === 'buy'
+        ? { ...cost, coin: Math.max(cost.coin - 1, 1) }
+        : cost,
+}
+
+const blacksmith: Encounter = {
+    name: 'The Blacksmith',
+    createInitialData: () => ({ selectedIndex: null as number | null }),
+    getOptions(data: unknown, metaState: MetaState): RewardOption[] {
+        const { selectedIndex } = data as { selectedIndex: number | null }
+        const hasCards = metaState.data.collectedCards.length > 0
+
+        const chooseUpgrade = async (upgrade: CardUpgrade, index: number) => {
+            const card = await metaState.ui.chooseCard(
+                metaState,
+                'Choose a card to upgrade:',
+                [...metaState.data.collectedCards],
+                true
+            )
+            if (!card) {
+                return { newData: data }
+            }
+            return {
+                newData: { selectedIndex: index },
+                transform: async (state: MetaState) => {
+                    const updated = upgradeCardSpec(card, upgrade)
+                    const cards = [...state.data.collectedCards]
+                    const cardIndex = cards.indexOf(card)
+                    if (cardIndex >= 0) {
+                        cards[cardIndex] = updated
+                        state.update({ collectedCards: cards })
+                    }
+                }
+            }
+        }
+
+        return [
+            {
+                label: 'Polish',
+                description: 'Add +$1 to a card.',
+                disabled: selectedIndex !== null || !hasCards,
+                checked: selectedIndex === 0,
+                onClick: async () => chooseUpgrade(polishUpgrade, 0),
+            },
+            {
+                label: 'Sharpen',
+                description: 'Add +1 action to a card.',
+                disabled: selectedIndex !== null || !hasCards,
+                checked: selectedIndex === 1,
+                onClick: async () => chooseUpgrade(sharpenUpgrade, 1),
+            },
+            {
+                label: 'Redesign',
+                description: 'Reduce the buy cost by $1 (not below $1).',
+                disabled: selectedIndex !== null || !hasCards,
+                checked: selectedIndex === 2,
+                onClick: async () => chooseUpgrade(redesignUpgrade, 2),
+            }
+        ]
+    }
+}
+registerEncounter(blacksmith)
 
 // Variety Pack encounter - pre-generates options at creation time
 const varietyPack: Encounter = {

--- a/gameLogic.ts
+++ b/gameLogic.ts
@@ -3,6 +3,7 @@
 
 export interface CardSpec {
     name: string;
+    upgrades?: CardUpgrade[];
     fixedCost?: Cost;
     restrictions?: Restriction[];
     variableCosts?: VariableCost[];
@@ -17,6 +18,76 @@ export interface CardSpec {
     simpleText?: string[]; // Short description for card selector/deck view (one line per array element)
     isPotion?: boolean; // If true, trash after playing
     rules?: Rule[]; // Rules this card references (for tooltip display)
+}
+
+export interface CardUpgrade {
+    name?: (name: string) => string;
+    effects?: Effect[];
+    triggers?: TypedTrigger[];
+    staticTriggers?: TypedTrigger[];
+    replacers?: TypedReplacer[];
+    staticReplacers?: TypedReplacer[];
+    cost?: (cost: Cost, kind: ActionKind) => Cost;
+}
+
+function appendUpgrades<T>(
+    base: T[] | undefined,
+    upgrades: CardUpgrade[] | undefined,
+    getter: (upgrade: CardUpgrade) => T[] | undefined
+): T[] {
+    const result = base ? [...base] : []
+    if (!upgrades) return result
+    for (const upgrade of upgrades) {
+        const extra = getter(upgrade)
+        if (extra) result.push(...extra)
+    }
+    return result
+}
+
+export function cardSpecName(spec: CardSpec): string {
+    let name = spec.name
+    for (const upgrade of spec.upgrades || []) {
+        if (upgrade.name) {
+            name = upgrade.name(name)
+        }
+    }
+    return name
+}
+
+export function cardSpecEffects(spec: CardSpec): Effect[] {
+    return appendUpgrades(spec.effects, spec.upgrades, upgrade => upgrade.effects)
+}
+
+export function cardSpecTriggers(spec: CardSpec): TypedTrigger[] {
+    return appendUpgrades(spec.triggers, spec.upgrades, upgrade => upgrade.triggers)
+}
+
+export function cardSpecStaticTriggers(spec: CardSpec): TypedTrigger[] {
+    return appendUpgrades(spec.staticTriggers, spec.upgrades, upgrade => upgrade.staticTriggers)
+}
+
+export function cardSpecReplacers(spec: CardSpec): TypedReplacer[] {
+    return appendUpgrades(spec.replacers, spec.upgrades, upgrade => upgrade.replacers)
+}
+
+export function cardSpecStaticReplacers(spec: CardSpec): TypedReplacer[] {
+    return appendUpgrades(spec.staticReplacers, spec.upgrades, upgrade => upgrade.staticReplacers)
+}
+
+export function applyCardUpgradeCost(spec: CardSpec, cost: Cost, kind: ActionKind): Cost {
+    let result = cost
+    for (const upgrade of spec.upgrades || []) {
+        if (upgrade.cost) {
+            result = upgrade.cost(result, kind)
+        }
+    }
+    return result
+}
+
+export function cardSpecCost(spec: CardSpec, kind: ActionKind): Cost | undefined {
+    const base = kind === 'buy' ? spec.buyCost : spec.fixedCost
+    if (!base) return undefined
+    return applyCardUpgradeCost(spec, base, kind)
 }
 
 // Rules are global triggers/replacers that apply to all games
@@ -95,7 +166,6 @@ export interface CardUpdate {
 }
 
 export class Card {
-    readonly name: string;
     readonly charge: number;
     public readonly kind = 'card'
     constructor(
@@ -107,8 +177,10 @@ export class Card {
         // we assign each card the smallest unused index in its current zone, for consistency of hotkey mappings
         public readonly zoneIndex = 0,
     ) {
-        this.name = spec.name
         this.charge = this.count('charge')
+    }
+    get name(): string {
+        return cardSpecName(this.spec)
     }
     toString():string {
         return this.name
@@ -157,8 +229,11 @@ export class Card {
                 }
 
                 if (kind == 'play') result = addCosts(result, {actions:1});
-                return result
-            case 'buy': return addCosts(this.spec.buyCost || free, {buys:1})
+                return applyCardUpgradeCost(this.spec, result, kind)
+            case 'buy': {
+                const result = addCosts(this.spec.buyCost || free, {buys:1})
+                return applyCardUpgradeCost(this.spec, result, kind)
+            }
             case 'activate': return free
             case 'potion': return free
             default: return assertNever(kind)
@@ -322,19 +397,19 @@ export class Card {
         return this.spec.ability || []
     }
     effects(): Effect[] {
-        return this.spec.effects || []
+        return cardSpecEffects(this.spec)
     }
     triggers(): TypedTrigger[] {
-        return this.spec.triggers || []
+        return cardSpecTriggers(this.spec)
     }
     staticTriggers(): TypedTrigger[] {
-        return this.spec.staticTriggers|| []
+        return cardSpecStaticTriggers(this.spec)
     }
     replacers(): TypedReplacer[] {
-        return this.spec.replacers || []
+        return cardSpecReplacers(this.spec)
     }
     staticReplacers(): TypedReplacer[] {
-        return this.spec.staticReplacers|| []
+        return cardSpecStaticReplacers(this.spec)
     }
     relatedCards(): CardSpec[] {
         return this.spec.relatedCards || []
@@ -1719,22 +1794,23 @@ function actChoice(state:State): Promise<[State, [Card, ActionKind]|null]> {
 // ------------------------------ Start the game
 
 export function coinKey(spec:CardSpec): number {
-    if (spec.buyCost !== undefined)
-        return spec.buyCost.coin
+    const cost = cardSpecCost(spec, 'buy')
+    if (cost)
+        return cost.coin
     return 0
 }
 export function coinEventKey(spec:CardSpec): number {
-    return (spec.fixedCost || free).coin
+    return (cardSpecCost(spec, 'use') || free).coin
 }
 export function energyEventKey(spec:CardSpec): number {
-    return (spec.fixedCost || free).energy
+    return (cardSpecCost(spec, 'use') || free).energy
 }
 export type Comp<T> = (a:T, b:T) => number
 export function toComp<T>(key:(x:T) => number): Comp<T> {
     return (a, b) => key(a) - key(b)
 }
 export function nameComp(a:CardSpec, b:CardSpec): number {
-    return a.name.localeCompare(b.name, 'en')
+    return cardSpecName(a).localeCompare(cardSpecName(b), 'en')
 }
 function lexical<T>(comps:Comp<T>[]): Comp<T> {
     return function(a:T, b:T){
@@ -2458,7 +2534,7 @@ export const villager:CardSpec = {
     }, trashOnLeavePlay()]
 }
 
-export function playReplacer<S>(
+export function playReplacer<S extends Source>(
     text:string,
     condition: (p: CreateParams, s:State, source:S) => boolean,
     cost: (p:CreateParams, s:State, source:S) => Transform
@@ -2472,7 +2548,7 @@ export function playReplacer<S>(
             t => async function(state) {
                 t = state.find(t)
                 if (t.place == 'void') {
-                    state = await t.play(source as Source)(state)
+                    state = await t.play(source)(state)
                 }
                 return state
             }

--- a/gameUI.ts
+++ b/gameUI.ts
@@ -4,6 +4,7 @@
 import { Cost, Shadow, State, Card, CardSpec, PlaceName, Rule, ID, VictoryData, UndoPastBeginning } from './gameLogic.js'
 import { GameSpec, SlotSpec } from './gameLogic.js'
 import { Trigger, Replacer, VariableCost, Token } from './gameLogic.js'
+import { cardSpecCost, cardSpecEffects, cardSpecName, cardSpecReplacers, cardSpecStaticReplacers, cardSpecStaticTriggers, cardSpecTriggers } from './gameLogic.js'
 import { renderCost, renderEnergy } from './gameLogic.js'
 import { LogType, logTypes } from './gameLogic.js'
 import { Option, OptionRender, HotkeyHint } from './gameLogic.js'
@@ -323,7 +324,7 @@ function describeCost(cost: Cost): string {
 
 function renderEffects(spec: CardSpec): string {
     const parts: string[] = []
-    for (const effect of spec.effects || []) {
+    for (const effect of cardSpecEffects(spec)) {
         parts.push(...effect.text)
     }
     return parts.map(x => `<div>${x}</div>`).join('')
@@ -371,10 +372,10 @@ export function cardText(spec: CardSpec): string {
         spec.variableCosts ? renderVariableCosts(spec.variableCosts) : '',
         renderEffects(spec),
         renderAbility(spec),
-        (spec.triggers || []).map(x => renderTrigger(x, false)).join(''),
-        (spec.replacers || []).map(x => renderTrigger(x, false)).join(''),
-        (spec.staticTriggers || []).map(x => renderTrigger(x, true)).join(''),
-        (spec.staticReplacers || []).map(x => renderTrigger(x, true)).join(''),
+        cardSpecTriggers(spec).map(x => renderTrigger(x, false)).join(''),
+        cardSpecReplacers(spec).map(x => renderTrigger(x, false)).join(''),
+        cardSpecStaticTriggers(spec).map(x => renderTrigger(x, true)).join(''),
+        cardSpecStaticReplacers(spec).map(x => renderTrigger(x, true)).join(''),
         (spec.rules || []).map(renderRuleText).join('')
     ].join('')
 }
@@ -382,8 +383,11 @@ export function cardText(spec: CardSpec): string {
 // ----------------------------- Tooltip Rendering
 
 function renderTooltipSimple(card: Card, state: State, tokenRenderer: TokenRenderer): string {
-    const buyStr = !isZero(card.spec.buyCost) ? `(${renderCost(card.spec.buyCost!)})` : '---'
-    const costStr = !isZero(card.spec.fixedCost) ? `(${renderCost(card.spec.fixedCost!)})` : '---'
+    const costKind = card.place === 'events' ? 'use' : 'play'
+    const buyCost = cardSpecCost(card.spec, 'buy')
+    const playCost = cardSpecCost(card.spec, costKind)
+    const buyStr = !isZero(buyCost) ? `(${renderCost(buyCost!)})` : '---'
+    const costStr = !isZero(playCost) ? `(${renderCost(playCost!)})` : '---'
     const header = `<div>---${buyStr} ${card.name} ${costStr}---</div>`
     const tokensHtml = tokenRenderer.renderTooltip(card.tokens)
     const bodyText = card.spec.simpleText
@@ -393,8 +397,11 @@ function renderTooltipSimple(card: Card, state: State, tokenRenderer: TokenRende
 }
 
 function renderTooltipFull(card: Card, state: State, tokenRenderer: TokenRenderer): string {
-    const buyStr = !isZero(card.spec.buyCost) ? `(${renderCost(card.spec.buyCost!)})` : '---'
-    const costStr = !isZero(card.spec.fixedCost) ? `(${renderCost(card.spec.fixedCost!)})` : '---'
+    const costKind = card.place === 'events' ? 'use' : 'play'
+    const buyCost = cardSpecCost(card.spec, 'buy')
+    const playCost = cardSpecCost(card.spec, costKind)
+    const buyStr = !isZero(buyCost) ? `(${renderCost(buyCost!)})` : '---'
+    const costStr = !isZero(playCost) ? `(${renderCost(playCost!)})` : '---'
     const header = `<div>---${buyStr} ${card.name} ${costStr}---</div>`
     const tokensHtml = tokenRenderer.renderTooltip(card.tokens)
     const baseFilling = header + cardText(card.spec) + tokensHtml
@@ -485,27 +492,33 @@ function renderCard(
 // ----------------------------- Spec Rendering (for meta UI)
 
 export function renderSpec(spec: CardSpec): string {
-    const buyText = isZero(spec.buyCost) ? '' : `(${renderCost(spec.buyCost!)})&nbsp;`
-    const costText = isZero(spec.fixedCost) ? '' : `&nbsp;(${renderCost(spec.fixedCost!)})`
-    const header = `<div>${buyText}<strong>${spec.name}</strong>${costText}</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyText = isZero(buyCost) ? '' : `(${renderCost(buyCost!)})&nbsp;`
+    const costText = isZero(playCost) ? '' : `&nbsp;(${renderCost(playCost!)})`
+    const header = `<div>${buyText}<strong>${cardSpecName(spec)}</strong>${costText}</div>`
     const me = `<div class='spec'>${header}${cardText(spec)}</div>`
     const related = (spec.relatedCards || []).map(renderSpec)
     return [me, ...related].join('')
 }
 
 export function buildSpecTooltip(spec: CardSpec): string {
-    const buyStr = !isZero(spec.buyCost) ? `(${renderCost(spec.buyCost!)})` : '---'
-    const costStr = !isZero(spec.fixedCost) ? `(${renderCost(spec.fixedCost!)})` : '---'
-    const header = `<div>---${buyStr} ${spec.name} ${costStr}---</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyStr = !isZero(buyCost) ? `(${renderCost(buyCost!)})` : '---'
+    const costStr = !isZero(playCost) ? `(${renderCost(playCost!)})` : '---'
+    const header = `<div>---${buyStr} ${cardSpecName(spec)} ${costStr}---</div>`
     const baseFilling = header + cardText(spec)
     const relatedFilling = (spec.relatedCards || []).map(buildSpecTooltip).join('')
     return baseFilling + relatedFilling
 }
 
 export function renderSpecNoRelated(spec: CardSpec): string {
-    const buyText = isZero(spec.buyCost) ? '' : `(${renderCost(spec.buyCost!)})&nbsp;`
-    const costText = isZero(spec.fixedCost) ? '' : `&nbsp;(${renderCost(spec.fixedCost!)})`
-    const header = `<div>${buyText}<strong>${spec.name}</strong>${costText}</div>`
+    const buyCost = cardSpecCost(spec, 'buy')
+    const playCost = cardSpecCost(spec, 'play')
+    const buyText = isZero(buyCost) ? '' : `(${renderCost(buyCost!)})&nbsp;`
+    const costText = isZero(playCost) ? '' : `&nbsp;(${renderCost(playCost!)})`
+    const header = `<div>${buyText}<strong>${cardSpecName(spec)}</strong>${costText}</div>`
     const displayText = spec.simpleText
         ? spec.simpleText.map(line => `<div>${line}</div>`).join('')
         : cardText(spec)

--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,7 @@ import { playGame } from './metaLogic.js'
 import { MetaGameUI } from './metaUI.js'
 import { randomString } from './rng.js'
 
-import { type TestSpec } from './metaLogic.js'
+import type { TestSpec } from './metaLogic.js'
 
 import { tradingPost } from './data/encounters.js'
 import { resume } from './data/events.js'

--- a/metaLogic.ts
+++ b/metaLogic.ts
@@ -1,7 +1,7 @@
 // metaLogic.ts - Meta-game state and transformations
 // This handles the roguelike progression layer on top of the core game.
 
-import { CardSpec, Card, type GameSpec, State, vpModes,
+import { CardSpec, Card, State, vpModes,
     TypedTrigger, TypedReplacer,
     Boon, VPMode,
     boons,
@@ -12,6 +12,7 @@ import { CardSpec, Card, type GameSpec, State, vpModes,
     VictoryData,
     Replayable
  } from './gameLogic.js'
+import type { GameSpec } from './gameLogic.js'
 
 import { buildSpecTooltip } from './cardRendering.js'
 
@@ -97,9 +98,10 @@ export type RewardState = SimpleRewardState | EncounterRewardState
 
 // Get options for a simple reward
 function getSimpleRewardOptions(state: SimpleRewardState, metaState: MetaState): RewardOption[] {
-    return state.options.map((option, i) => ({
+    const options = state.options as Array<CardSpec | RelicSpec>
+    return options.map((option: CardSpec | RelicSpec, i: number) => ({
         label: option.name,
-        spec: option,
+        spec: option as CardSpec,
         disabled: state.selectedIndex !== null,
         checked: state.selectedIndex === i,
         onClick: async () => {


### PR DESCRIPTION
### Motivation
- The project failed to compile due to TypeScript incompatibilities (type-only import syntax not supported by the installed TS version), a union-`map` typing issue in reward option rendering, a `MetaTransform` mismatch for encounter transforms, and an unsafe `Source` cast in a replacer helper.

### Description
- Replace unsupported `import { type ... }` with TS3.9-compatible `import type` and add a dedicated `import type { GameSpec }` to avoid parse/type errors in `main.ts` and `metaLogic.ts`.
- Fix the union-`map` problem in `getSimpleRewardOptions` by narrowing `state.options` to `Array<CardSpec | RelicSpec>` and typing the `map` callback explicitly so the returned `RewardOption` has consistent types.
- Make the Blacksmith encounter upgrade application return an `async` transform so the returned object matches the expected `MetaTransform` signature and add `upgradeCardSpec` helper and bottled-card display name fix to use upgraded display names.
- Tighten `playReplacer` generics to `S extends Source` and remove an unsafe `as Source` cast when calling `t.play(source)`, and update various UI/rendering helpers to use the upgrade-aware `cardSpec*` functions for name/cost/effects/triggers so display logic matches upgrade behavior.

### Testing
- Ran the TypeScript build with `npm run build`, which completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69856ae6f144832ebfceb95f31422820)